### PR TITLE
added permissions reset to site.sh

### DIFF
--- a/scripts/site.sh
+++ b/scripts/site.sh
@@ -16,6 +16,7 @@ enable_git_deploment() {
 	echo "Setting up git deployment..."
 
 	ssh -t $user@$ip "
+        sudo chmod g+srwx /srv
 	mkdir /srv/${domain}
 	cat > /srv/${domain}/config <<'.'
 $(cat $TEMPLATES/config)


### PR DESCRIPTION
Permissions (setgid bit) to the /srv folder seem to be reset after a kernel update. Added "sudo chmod g+srwx /srv" to reset directory permissions before a new site is created. 
